### PR TITLE
Implement Choice restriction support and fix some related issues

### DIFF
--- a/app/src/main/java/com/afwsamples/testdpc/common/EditDeleteArrayAdapter.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/EditDeleteArrayAdapter.java
@@ -90,19 +90,6 @@ public abstract class EditDeleteArrayAdapter<T> extends ArrayAdapter<T>
         }
     }
 
-    @Override
-    public void notifyDataSetChanged() {
-        if (mEntries != null) {
-            Collections.sort(mEntries, new Comparator<T>() {
-                @Override
-                public int compare(T entry1, T entry2) {
-                    return getDisplayName(entry1).compareTo(getDisplayName(entry2));
-                }
-            });
-        }
-        super.notifyDataSetChanged();
-    }
-
     public void set(int index, T item) {
         mEntries.set(index, item);
         notifyDataSetChanged();
@@ -122,5 +109,16 @@ public abstract class EditDeleteArrayAdapter<T> extends ArrayAdapter<T>
 
     public interface OnDeleteButtonClickListener<T> {
         void onDeleteButtonClick(T entry);
+    }
+
+    protected void sort() {
+        if (mEntries != null) {
+            Collections.sort(mEntries, new Comparator<T>() {
+                @Override
+                public int compare(T entry1, T entry2) {
+                    return getDisplayName(entry1).compareTo(getDisplayName(entry2));
+                }
+            });
+        }
     }
 }

--- a/app/src/main/java/com/afwsamples/testdpc/common/RestrictionManagerCompat.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/RestrictionManagerCompat.java
@@ -32,9 +32,9 @@ public class RestrictionManagerCompat {
     private static final String TAG = "RestrictionManager";
 
     // These keys are used inside TesDPC only. We never save them to DevicePolicyManager
-    public static final String CHOICE_SELECTED_VALUE= "testdpc_arg_choice_selected_value";
-    public static final String CHOICE_ENTRIES= "testdpc_arg_choice_entries";
-    public static final String CHOICE_VALUES= "testdpc_arg_choice_values";
+    public static final String CHOICE_SELECTED_VALUE = "testdpc_arg_choice_selected_value";
+    public static final String CHOICE_ENTRIES = "testdpc_arg_choice_entries";
+    public static final String CHOICE_VALUES = "testdpc_arg_choice_values";
 
 
     /**

--- a/app/src/main/java/com/afwsamples/testdpc/common/RestrictionManagerCompat.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/RestrictionManagerCompat.java
@@ -31,12 +31,6 @@ import java.util.List;
 public class RestrictionManagerCompat {
     private static final String TAG = "RestrictionManager";
 
-    // These keys are used inside TesDPC only. We never save them to DevicePolicyManager
-    public static final String CHOICE_SELECTED_VALUE = "testdpc_arg_choice_selected_value";
-    public static final String CHOICE_ENTRIES = "testdpc_arg_choice_entries";
-    public static final String CHOICE_VALUES = "testdpc_arg_choice_values";
-
-
     /**
      * Converts a list of restrictions to the corresponding bundle, using the following mapping:
      * <table>
@@ -53,17 +47,16 @@ public class RestrictionManagerCompat {
      * </table>
      * TYPE_BUNDLE and TYPE_BUNDLE_ARRAY are supported from api level 23 onwards.
      * @param entries list of restrictions
-     * @param saveChoiceDataForDialog if true, then Choice restriction will be converted into Bundle with entries and values
      */
-    public static Bundle convertRestrictionsToBundle(List<RestrictionEntry> entries, boolean saveChoiceDataForDialog) {
+    public static Bundle convertRestrictionsToBundle(List<RestrictionEntry> entries) {
         final Bundle bundle = new Bundle();
         for (RestrictionEntry entry : entries) {
-            addRestrictionToBundle(bundle, entry, saveChoiceDataForDialog);
+            addRestrictionToBundle(bundle, entry);
         }
         return bundle;
     }
 
-    private static Bundle addRestrictionToBundle(Bundle bundle, RestrictionEntry entry, boolean saveChoiceDataForDialog) {
+    private static Bundle addRestrictionToBundle(Bundle bundle, RestrictionEntry entry) {
         switch (entry.getType()) {
             case RestrictionEntry.TYPE_BOOLEAN:
                 bundle.putBoolean(entry.getKey(), entry.getSelectedState());
@@ -75,32 +68,15 @@ public class RestrictionManagerCompat {
                 bundle.putInt(entry.getKey(), entry.getIntValue());
                 break;
             case RestrictionEntry.TYPE_STRING:
-                // UI uses value to find restriction type.
-                // If string restrictions has null value, it will be displayed as boolean
-                // To avoid this we should set empty string as value
-                String value = entry.getSelectedString();
-                if (value == null) {
-                    value = "";
-                }
-                bundle.putString(entry.getKey(), value);
-                break;
+            case RestrictionEntry.TYPE_CHOICE:
             case RestrictionEntry.TYPE_NULL:
                 bundle.putString(entry.getKey(), entry.getSelectedString());
                 break;
             case RestrictionEntry.TYPE_BUNDLE:
-                addBundleRestrictionToBundle(bundle, entry, saveChoiceDataForDialog);
+                addBundleRestrictionToBundle(bundle, entry);
                 break;
             case RestrictionEntry.TYPE_BUNDLE_ARRAY:
-                addBundleArrayRestrictionToBundle(bundle, entry, saveChoiceDataForDialog);
-                break;
-            case RestrictionEntry.TYPE_CHOICE:
-                // For UI we are adding entries and values of Choice restriction
-                // For DevicePolicyManager we are saving selected string value only
-                if (saveChoiceDataForDialog) {
-                    bundle.putBundle(entry.getKey(), convertChoiceRestrictionToBundle(entry));
-                } else {
-                    bundle.putString(entry.getKey(), entry.getSelectedString());
-                }
+                addBundleArrayRestrictionToBundle(bundle, entry);
                 break;
             default:
                 throw new IllegalArgumentException(
@@ -110,10 +86,10 @@ public class RestrictionManagerCompat {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    private static void addBundleRestrictionToBundle(Bundle bundle, RestrictionEntry entry, boolean saveChoiceDataForDialog) {
+    private static void addBundleRestrictionToBundle(Bundle bundle, RestrictionEntry entry) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             RestrictionEntry[] restrictions = entry.getRestrictions();
-            Bundle childBundle = convertRestrictionsToBundle(Arrays.asList(restrictions), saveChoiceDataForDialog);
+            Bundle childBundle = convertRestrictionsToBundle(Arrays.asList(restrictions));
             bundle.putBundle(entry.getKey(), childBundle);
         } else {
             Log.w(TAG, "addBundleRestrictionToBundle is called in pre-M");
@@ -121,7 +97,7 @@ public class RestrictionManagerCompat {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    private static void addBundleArrayRestrictionToBundle(Bundle bundle, RestrictionEntry entry, boolean saveChoiceDataForDialog) {
+    private static void addBundleArrayRestrictionToBundle(Bundle bundle, RestrictionEntry entry) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             RestrictionEntry[] bundleRestrictionArray = entry.getRestrictions();
             Bundle[] bundleArray = new Bundle[bundleRestrictionArray.length];
@@ -135,28 +111,12 @@ public class RestrictionManagerCompat {
                     bundleArray[i] = new Bundle();
                 } else {
                     bundleArray[i] = convertRestrictionsToBundle(Arrays.asList(
-                            bundleRestrictions), saveChoiceDataForDialog);
+                            bundleRestrictions));
                 }
             }
             bundle.putParcelableArray(entry.getKey(), bundleArray);
         } else {
             Log.w(TAG, "addBundleArrayRestrictionToBundle is called in pre-M");
         }
-    }
-
-    /*
-     * Saves Choice restriction data to Bundle for UI
-     * @param restrictionEntry Choice restriction entry
-     */
-    public static Bundle convertChoiceRestrictionToBundle(RestrictionEntry restrictionEntry) {
-        Bundle choiceData = new Bundle();
-
-        if (restrictionEntry != null) {
-            choiceData.putString(CHOICE_SELECTED_VALUE, restrictionEntry.getSelectedString());
-            choiceData.putStringArray(CHOICE_ENTRIES, restrictionEntry.getChoiceEntries());
-            choiceData.putStringArray(CHOICE_VALUES, restrictionEntry.getChoiceValues());
-        }
-
-        return choiceData;
     }
 }

--- a/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueBundleArrayFragment.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueBundleArrayFragment.java
@@ -19,6 +19,7 @@ package com.afwsamples.testdpc.common.keyvaluepair;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.RestrictionEntry;
 import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -40,13 +41,16 @@ import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragm
 import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment
         .ARG_INITIAL_VALUE;
 import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment.ARG_KEY;
+import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment
+        .ARG_RESTRICTION_ENTRY;
 import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment.DialogType;
+import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment.RESULT_ENTRY;
 import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment.RESULT_KEY;
 import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment.RESULT_TYPE;
 import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment.RESULT_VALUE;
 
 public class KeyValueBundleArrayFragment extends ManageAppFragment implements
-        OnEditButtonClickListener<Bundle>, OnDeleteButtonClickListener<Bundle> {
+        OnEditButtonClickListener<Integer>, OnDeleteButtonClickListener<Integer> {
     /**
      * Key of the editing bundle array.
      */
@@ -54,18 +58,21 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
     /**
      * The current bundle list.
      */
-    private List<Bundle> mBundleList;
+    private ArrayList<Object> mBundleList;
     /**
      * The initial value of the passed in bundle list.
      */
-    private List<Bundle> mInitialBundleList;
+    private ArrayList<Object> mInitialBundleList;
     private String mAppName;
-    private BundleEditDeleteArrayAdapter mAdapter;
+    private EditDeleteArrayAdapter mAdapter;
+    private RestrictionEntry mBundleArrayRestrictionEntry;
+    private Integer mEditingItemNumber;
+    List<Integer> mBundleNumbers;
 
     private static final int RESULT_CODE_EDIT_DIALOG = 1;
 
     private static final int[] SUPPORTED_TYPE = {
-            DialogType.BUNDLE_TYPE,
+            DialogType.BUNDLE_TYPE
     };
 
     /**
@@ -73,10 +80,11 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
      * @param bundles initial value of the bundle array for editing.
      */
     public static KeyValueBundleArrayFragment newInstance(String key, Bundle[] bundles,
-            String appName) {
+            RestrictionEntry entry, String appName) {
         Bundle arguments = new Bundle();
         arguments.putString(ARG_KEY, key);
         arguments.putParcelableArray(ARG_INITIAL_VALUE, bundles);
+        arguments.putParcelable(ARG_RESTRICTION_ENTRY, entry);
         arguments.putString(ARG_APP_NAME, appName);
         KeyValueBundleArrayFragment fragment = new KeyValueBundleArrayFragment();
         fragment.setArguments(arguments);
@@ -87,12 +95,37 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mKey = getArguments().getString(ARG_KEY);
-        Bundle[] bundles = (Bundle[]) getArguments().getParcelableArray(ARG_INITIAL_VALUE);
+        Object[] bundles = getArguments().getParcelableArray(ARG_INITIAL_VALUE);
         if (bundles == null) {
             bundles = new Bundle[0];
         }
-        mBundleList = new ArrayList<>(Arrays.asList(bundles));
-        mInitialBundleList = new ArrayList<>(mBundleList);
+        mBundleArrayRestrictionEntry = (RestrictionEntry) getArguments().getParcelable(
+                ARG_RESTRICTION_ENTRY);
+
+        if (mBundleArrayRestrictionEntry != null) {
+            // If we received RestrictionEntry with wrong type, we will make new empty BundleArray
+            // restriction with same key, title and description
+            if (mBundleArrayRestrictionEntry.getType() != RestrictionEntry.TYPE_BUNDLE_ARRAY) {
+                RestrictionEntry newBundleEntry = KeyValueUtil.createBundleArrayRestriction(
+                        mKey, new RestrictionEntry[0]);
+                if (newBundleEntry != null) {
+                    newBundleEntry.setTitle(mBundleArrayRestrictionEntry.getTitle());
+                    newBundleEntry.setDescription(mBundleArrayRestrictionEntry.getDescription());
+                }
+                mBundleArrayRestrictionEntry = newBundleEntry;
+            }
+            RestrictionEntry[] entries = KeyValueUtil.getRestrictionEntries(
+                    mBundleArrayRestrictionEntry);
+            if (entries == null){
+                entries = new RestrictionEntry[0];
+            }
+            mBundleList = new ArrayList<>(Arrays.asList((Object[])entries));
+            mInitialBundleList = KeyValueUtil.cloneRestrictionsList(mBundleList);
+        } else {
+            mBundleList = new ArrayList<>(Arrays.asList(bundles));
+            mInitialBundleList = new ArrayList<>(mBundleList);
+        }
+        mBundleNumbers = getBundleNumbers(mBundleList);
         mAppName = getArguments().getString(ARG_APP_NAME);
     }
 
@@ -114,7 +147,10 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
     @Override
     protected void resetConfig() {
         mAdapter.clear();
-        mAdapter.addAll(mInitialBundleList);
+        mBundleList.clear();
+        mBundleList = new ArrayList<>(mInitialBundleList);
+        mBundleNumbers = getBundleNumbers(mInitialBundleList);
+        mAdapter.addAll(mBundleNumbers);
     }
 
     @Override
@@ -122,23 +158,45 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
         Intent intent = new Intent();
         intent.putExtra(RESULT_KEY, mKey);
         intent.putExtra(RESULT_TYPE, DialogType.BUNDLE_ARRAY_TYPE);
-        intent.putExtra(RESULT_VALUE, mBundleList.toArray(new Bundle[0]));
+        if (mBundleArrayRestrictionEntry != null) {
+            KeyValueUtil.setRestrictionEntries(mBundleArrayRestrictionEntry,
+                    mBundleList.toArray(new RestrictionEntry[0]));
+            intent.putExtra(RESULT_ENTRY, mBundleArrayRestrictionEntry);
+        } else  {
+            intent.putExtra(RESULT_VALUE, mBundleList.toArray(new Bundle[0]));
+        }
         getTargetFragment().onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, intent);
         getFragmentManager().popBackStack();
     }
 
     @Override
     protected void addNewRow() {
-        Bundle bundle = null;
         // Use same bundle structure as first bundle, if exists
         // In case of empty bundle user will need to add all restrictions manually
-        if (mInitialBundleList != null && mInitialBundleList.size() > 0 && mInitialBundleList.get(0) != null) {
-            bundle = (Bundle) mInitialBundleList.get(0).clone();
+        if (mInitialBundleList.size() > 0
+                && mInitialBundleList.get(0) != null) {
+            if (mBundleArrayRestrictionEntry != null) {
+                RestrictionEntry newEntry = KeyValueUtil.cloneRestriction(
+                        (RestrictionEntry) mInitialBundleList.get(0));
+                mBundleList.add(newEntry);
+            } else {
+                Bundle bundle = (Bundle)((Bundle) mInitialBundleList.get(0)).clone();
+                mBundleList.add(bundle);
+            }
         } else {
-            bundle = new Bundle();
+            Bundle bundle = null;
+            if (mBundleArrayRestrictionEntry != null) {
+                RestrictionEntry newEntry = KeyValueUtil.createBundleRestriction(
+                        mBundleArrayRestrictionEntry.getKey(), new RestrictionEntry[0]);
+                mBundleList.add(newEntry);
+            } else {
+                bundle = new Bundle();
+                mBundleList.add(bundle);
+            }
         }
-        mAdapter.add(bundle);
-        showEditDialog(bundle);
+        mEditingItemNumber = mBundleList.size()-1;
+        mAdapter.add(mEditingItemNumber);
+        showEditDialog(mEditingItemNumber);
     }
 
     @Override
@@ -146,28 +204,40 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
 
     @Override
     protected BaseAdapter createListAdapter() {
-        mAdapter = new BundleEditDeleteArrayAdapter(getActivity(), mBundleList, this, this);
+            mAdapter = new BundleEditDeleteArrayAdapter(getActivity(), mBundleNumbers, this, this);
         return mAdapter;
     }
 
-    private void showEditDialog(final Bundle bundle) {
+    private void showEditDialog(final int itemNumber) {
         int type = DialogType.BUNDLE_TYPE;
-        int index = mBundleList.indexOf(bundle);
-        KeyValuePairDialogFragment dialogFragment =
-                KeyValuePairDialogFragment.newInstance(type, false, "Bundle #" + index,
-                        bundle, SUPPORTED_TYPE, mAppName);
-        dialogFragment.setTargetFragment(this, RESULT_CODE_EDIT_DIALOG);
-        dialogFragment.show(getFragmentManager(), "dialog");
+        Bundle bundle = null;
+        RestrictionEntry editingEntry = null;
+        mEditingItemNumber = itemNumber;
+        if (itemNumber < mBundleList.size()) {
+            if (mBundleArrayRestrictionEntry != null) {
+                editingEntry = (RestrictionEntry) mBundleList.get(itemNumber);
+            } else {
+                bundle = (Bundle) mBundleList.get(itemNumber);
+            }
+            KeyValuePairDialogFragment dialogFragment =
+                    KeyValuePairDialogFragment.newInstance(type, false, "Bundle #" + itemNumber,
+                            bundle, editingEntry, SUPPORTED_TYPE, mAppName);
+            dialogFragment.setTargetFragment(this, RESULT_CODE_EDIT_DIALOG);
+            dialogFragment.show(getFragmentManager(), "dialog");
+        }
     }
 
     @Override
-    public void onEditButtonClick(Bundle bundle) {
-        showEditDialog(bundle);
+    public void onEditButtonClick(Integer entryNumber) {
+        showEditDialog(entryNumber);
     }
 
     @Override
-    public void onDeleteButtonClick(Bundle bundle) {
-        mBundleList.remove(bundle);
+    public void onDeleteButtonClick(Integer entryNumber) {
+        mAdapter.clear();
+        mBundleList.remove((int)entryNumber);
+        mBundleNumbers = getBundleNumbers(mBundleList);
+        mAdapter.addAll(mBundleNumbers);
     }
 
     @Override
@@ -177,22 +247,38 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
         }
         if (requestCode == RESULT_CODE_EDIT_DIALOG) {
             Bundle value = result.getBundleExtra(RESULT_VALUE);
-            int index = mBundleList.indexOf(value);
-            mAdapter.set(index, value);
+            RestrictionEntry entry = result.getParcelableExtra(RESULT_ENTRY);
+            if (entry != null) {
+                mBundleList.set(mEditingItemNumber, entry);
+            } else {
+                mBundleList.set(mEditingItemNumber, value);
+            }
+            mAdapter.set(mEditingItemNumber, mEditingItemNumber);
+            mEditingItemNumber = null;
         }
     }
 
-    private class BundleEditDeleteArrayAdapter extends EditDeleteArrayAdapter<Bundle> {
+    private class BundleEditDeleteArrayAdapter extends EditDeleteArrayAdapter<Integer> {
 
-        public BundleEditDeleteArrayAdapter(Context context, List<Bundle> entries,
+        public BundleEditDeleteArrayAdapter(Context context, List<Integer> entries,
                 OnEditButtonClickListener onEditButtonClickListener,
                 OnDeleteButtonClickListener onDeleteButtonClickListener) {
             super(context, entries, onEditButtonClickListener, onDeleteButtonClickListener);
         }
 
         @Override
-        protected String getDisplayName(Bundle entry) {
-            return String.valueOf("Bundle #" + mBundleList.indexOf(entry));
+        protected String getDisplayName(Integer entryNumber) {
+            return String.valueOf("Bundle #" + entryNumber);
         }
+    }
+
+    private List<Integer> getBundleNumbers(List<Object> entries) {
+        List<Integer> numbers = new ArrayList<>();
+        if (entries != null) {
+            for (int i=0; i<entries.size(); i++) {
+                numbers.add(i);
+            }
+        }
+        return numbers;
     }
 }

--- a/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueBundleArrayFragment.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueBundleArrayFragment.java
@@ -120,7 +120,7 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
                 entries = new RestrictionEntry[0];
             }
             mBundleList = new ArrayList<>(Arrays.asList((Object[])entries));
-            mInitialBundleList = KeyValueUtil.cloneRestrictionsList(mBundleList);
+            mInitialBundleList = KeyValueUtil.cloneRestrictionsListAsObjects(mBundleList);
         } else {
             mBundleList = new ArrayList<>(Arrays.asList(bundles));
             mInitialBundleList = new ArrayList<>(mBundleList);

--- a/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueBundleArrayFragment.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueBundleArrayFragment.java
@@ -129,7 +129,14 @@ public class KeyValueBundleArrayFragment extends ManageAppFragment implements
 
     @Override
     protected void addNewRow() {
-        Bundle bundle = new Bundle();
+        Bundle bundle = null;
+        // Use same bundle structure as first bundle, if exists
+        // In case of empty bundle user will need to add all restrictions manually
+        if (mInitialBundleList != null && mInitialBundleList.size() > 0 && mInitialBundleList.get(0) != null) {
+            bundle = (Bundle) mInitialBundleList.get(0).clone();
+        } else {
+            bundle = new Bundle();
+        }
         mAdapter.add(bundle);
         showEditDialog(bundle);
     }

--- a/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValuePairDialogFragment.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValuePairDialogFragment.java
@@ -371,6 +371,9 @@ public class KeyValuePairDialogFragment extends DialogFragment {
         setSupportedType(arguments.getIntArray(ARG_SUPPORTED_TYPE));
         setDialogType(arguments.getInt(ARG_DIALOG_TYPE));
         mRestrictionEntry = arguments.getParcelable(ARG_RESTRICTION_ENTRY);
+        if (mDialogType == DialogType.STRING_TYPE && !TextUtils.isEmpty(mKeyView.getText())) {
+            mStringView.requestFocus();
+        }
         if (mDialogType == DialogType.CHOICE_TYPE) {
             configureChoiceSpinner();
         }

--- a/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueUtil.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueUtil.java
@@ -20,6 +20,7 @@ package com.afwsamples.testdpc.common.keyvaluepair;
 import android.annotation.TargetApi;
 import android.content.RestrictionEntry;
 import android.os.Build;
+import android.text.TextUtils;
 
 import java.util.ArrayList;
 
@@ -154,7 +155,7 @@ public class KeyValueUtil {
         return RestrictionEntry.createBundleArrayEntry(key, restrictions);
     }
 
-    public static ArrayList<Object> cloneRestrictionsList(
+    public static ArrayList<Object> cloneRestrictionsListAsObjects(
             ArrayList<Object> originalList) {
         ArrayList<Object> newList = null;
         if (originalList != null) {
@@ -164,5 +165,28 @@ public class KeyValueUtil {
             }
         }
         return newList;
+    }
+
+    public static ArrayList<RestrictionEntry> cloneRestrictionsList(
+            ArrayList<RestrictionEntry> originalList) {
+        ArrayList<RestrictionEntry> newList = null;
+        if (originalList != null) {
+            newList = new ArrayList<>();
+            for (RestrictionEntry entry : originalList) {
+                newList.add(KeyValueUtil.cloneRestriction(entry));
+            }
+        }
+        return newList;
+    }
+
+    public static boolean keyAlreadyUsed(String key,ArrayList<RestrictionEntry> bundleRestrictions){
+        if (!TextUtils.isEmpty(key) && bundleRestrictions != null) {
+            for (RestrictionEntry entry : bundleRestrictions) {
+                if (entry != null && key.equals(entry.getKey())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueUtil.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/keyvaluepair/KeyValueUtil.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.afwsamples.testdpc.common.keyvaluepair;
+
+
+import android.annotation.TargetApi;
+import android.content.RestrictionEntry;
+import android.os.Build;
+
+import java.util.ArrayList;
+
+/**
+ * KeyValue dialogs utility functions.
+ */
+
+public class KeyValueUtil {
+
+    public static int getTypeIndexFromRestrictionType(int restrictionType) {
+        switch (restrictionType) {
+            case RestrictionEntry.TYPE_BOOLEAN:
+                return KeyValuePairDialogFragment.DialogType.BOOL_TYPE;
+            case RestrictionEntry.TYPE_INTEGER:
+                return KeyValuePairDialogFragment.DialogType.INT_TYPE;
+            case RestrictionEntry.TYPE_STRING:
+                return KeyValuePairDialogFragment.DialogType.STRING_TYPE;
+            case RestrictionEntry.TYPE_MULTI_SELECT:
+                return KeyValuePairDialogFragment.DialogType.STRING_ARRAY_TYPE;
+            case RestrictionEntry.TYPE_CHOICE:
+                return KeyValuePairDialogFragment.DialogType.CHOICE_TYPE;
+            case RestrictionEntry.TYPE_BUNDLE:
+                return KeyValuePairDialogFragment.DialogType.BUNDLE_TYPE;
+            case RestrictionEntry.TYPE_BUNDLE_ARRAY:
+                return KeyValuePairDialogFragment.DialogType.BUNDLE_ARRAY_TYPE;
+            default:
+                throw new AssertionError("Unknown restriction type");
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    public static RestrictionEntry[] getRestrictionEntries(RestrictionEntry restrictionEntry) {
+        return restrictionEntry.getRestrictions();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    public static void setRestrictionEntries(RestrictionEntry restrictionEntry,
+                                       RestrictionEntry[] restrictions) {
+        restrictionEntry.setRestrictions(restrictions);
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private static RestrictionEntry cloneBundleRestriction(RestrictionEntry oldEntry) {
+        RestrictionEntry newEntry = null;
+        if (oldEntry != null) {
+            RestrictionEntry[] newRestrictions = null;
+            RestrictionEntry[] oldRestrictions = oldEntry.getRestrictions();
+            if (oldRestrictions != null && oldRestrictions.length > 0) {
+                newRestrictions = new RestrictionEntry[oldRestrictions.length];
+                for (int i=0; i<oldRestrictions.length; i++) {
+                    newRestrictions[i] = cloneRestriction(oldRestrictions[i]);
+                }
+            }
+            String key = oldEntry.getKey();
+            newEntry = RestrictionEntry.createBundleEntry(key, newRestrictions);
+        }
+        return newEntry;
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private static RestrictionEntry cloneBundleArrayRestriction(RestrictionEntry oldEntry) {
+        RestrictionEntry newEntry = null;
+        if (oldEntry != null) {
+            RestrictionEntry[] newRestrictions = null;
+            RestrictionEntry[] oldRestrictions = oldEntry.getRestrictions();
+            if (oldRestrictions != null && oldRestrictions.length > 0) {
+                newRestrictions = new RestrictionEntry[oldRestrictions.length];
+                for (int i=0; i<oldRestrictions.length; i++) {
+                    newRestrictions[i] = cloneRestriction(oldRestrictions[i]);
+                }
+            }
+            String key = oldEntry.getKey();
+            newEntry = RestrictionEntry.createBundleArrayEntry(key, newRestrictions);
+        }
+        return newEntry;
+    }
+
+    public static RestrictionEntry cloneRestriction(RestrictionEntry oldEntry) {
+        RestrictionEntry newEntry = null;
+        if (oldEntry != null) {
+            String key = oldEntry.getKey();
+            switch (oldEntry.getType()) {
+                case RestrictionEntry.TYPE_BOOLEAN:
+                    newEntry = new RestrictionEntry(key,
+                            oldEntry.getSelectedState());
+                    break;
+                case RestrictionEntry.TYPE_INTEGER:
+                    newEntry = new RestrictionEntry(key,
+                            oldEntry.getIntValue());
+                    break;
+                case RestrictionEntry.TYPE_STRING:
+                    newEntry = new RestrictionEntry(RestrictionEntry.TYPE_STRING,key);
+                    newEntry.setSelectedString(oldEntry.getSelectedString());
+                    break;
+                case RestrictionEntry.TYPE_MULTI_SELECT:
+                    newEntry = new RestrictionEntry(key,
+                            oldEntry.getAllSelectedStrings());
+                    break;
+                case RestrictionEntry.TYPE_CHOICE:
+                    newEntry = new RestrictionEntry(RestrictionEntry.TYPE_CHOICE,key);
+                    newEntry.setSelectedString(oldEntry.getSelectedString());
+                    newEntry.setChoiceEntries(oldEntry.getChoiceEntries());
+                    newEntry.setChoiceValues(oldEntry.getChoiceValues());
+                    break;
+                case RestrictionEntry.TYPE_BUNDLE:
+                    newEntry = cloneBundleRestriction(oldEntry);
+                    break;
+                case RestrictionEntry.TYPE_BUNDLE_ARRAY:
+                    newEntry = cloneBundleArrayRestriction(oldEntry);
+                    break;
+                default:
+                    throw new AssertionError("Unknown restriction type");
+            }
+
+            if (newEntry != null) {
+                newEntry.setTitle(oldEntry.getTitle());
+                newEntry.setDescription(oldEntry.getDescription());
+            }
+        }
+        return newEntry;
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    public static RestrictionEntry createBundleRestriction(String key,
+            RestrictionEntry[] restrictions) {
+        return RestrictionEntry.createBundleEntry(key, restrictions);
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    public static RestrictionEntry createBundleArrayRestriction(String key,
+            RestrictionEntry[] restrictions) {
+        return RestrictionEntry.createBundleArrayEntry(key, restrictions);
+    }
+
+    public static ArrayList<Object> cloneRestrictionsList(
+            ArrayList<Object> originalList) {
+        ArrayList<Object> newList = null;
+        if (originalList != null) {
+            newList = new ArrayList<>();
+            for (Object entry : originalList) {
+                newList.add(KeyValueUtil.cloneRestriction((RestrictionEntry) entry));
+            }
+        }
+        return newList;
+    }
+}

--- a/app/src/main/java/com/afwsamples/testdpc/policy/keyguard/SetTrustAgentConfigFragment.java
+++ b/app/src/main/java/com/afwsamples/testdpc/policy/keyguard/SetTrustAgentConfigFragment.java
@@ -281,5 +281,11 @@ public class SetTrustAgentConfigFragment extends ManageResolveInfoFragment
         protected String getDisplayName(String entry) {
             return entry;
         }
+
+        @Override
+        public void notifyDataSetChanged() {
+            sort();
+            super.notifyDataSetChanged();
+        }
     }
 }

--- a/app/src/main/java/com/afwsamples/testdpc/policy/keyguard/SetTrustAgentConfigFragment.java
+++ b/app/src/main/java/com/afwsamples/testdpc/policy/keyguard/SetTrustAgentConfigFragment.java
@@ -197,7 +197,7 @@ public class SetTrustAgentConfigFragment extends ManageResolveInfoFragment
             }
         }
         KeyValuePairDialogFragment dialogFragment =
-                KeyValuePairDialogFragment.newInstance(type, true, key, value, SUPPORTED_TYPE,
+                KeyValuePairDialogFragment.newInstance(type, true, key, value, null, SUPPORTED_TYPE,
                         mResolveInfo.loadLabel(mPackageManager).toString());
         dialogFragment.setTargetFragment(this, RESULT_CODE_EDIT_DIALOG);
         dialogFragment.show(getFragmentManager(), "dialog");

--- a/app/src/main/java/com/afwsamples/testdpc/profilepolicy/apprestrictions/ManageAppRestrictionsFragment.java
+++ b/app/src/main/java/com/afwsamples/testdpc/profilepolicy/apprestrictions/ManageAppRestrictionsFragment.java
@@ -40,12 +40,14 @@ import com.afwsamples.testdpc.common.EditDeleteArrayAdapter;
 import com.afwsamples.testdpc.common.ManageAppFragment;
 import com.afwsamples.testdpc.common.RestrictionManagerCompat;
 import com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment;
+import com.afwsamples.testdpc.common.keyvaluepair.KeyValueUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment.RESULT_ENTRY;
 import static com.afwsamples.testdpc.common.keyvaluepair.KeyValuePairDialogFragment.RESULT_VALUE;
 
 /**
@@ -101,98 +103,136 @@ public class ManageAppRestrictionsFragment extends ManageAppFragment
         getActivity().getActionBar().setTitle(R.string.manage_app_restrictions);
     }
 
-    protected void loadAppRestrictionsList(RestrictionEntry[] restrictionEntries) {
+    protected void loadAppRestrictionsList(List<RestrictionEntry> restrictionEntries) {
         if (restrictionEntries != null) {
             mAppRestrictionsArrayAdapter.clear();
-            mAppRestrictionsArrayAdapter.addAll(Arrays.asList(restrictionEntries));
+            mAppRestrictionsArrayAdapter.addAll(restrictionEntries);
         }
     }
 
-    protected RestrictionEntry[] convertBundleToRestrictions(Bundle restrictionBundle, Bundle manifestRestrictionsBundle) {
-        List<RestrictionEntry> restrictionEntries = new ArrayList<>();
+    protected ArrayList<RestrictionEntry> convertBundleToRestrictions(
+            Bundle restrictionBundle, ArrayList<RestrictionEntry> manifestRestrictionEntries) {
+        ArrayList<RestrictionEntry> restrictionEntries = new ArrayList<>();
         Set<String> keys = restrictionBundle.keySet();
         for (String key : keys) {
             Object value = restrictionBundle.get(key);
+            RestrictionEntry currentEntry = findRestrictionEntryByKey(key,
+                manifestRestrictionEntries);
             if (value instanceof Boolean) {
-                restrictionEntries.add(new RestrictionEntry(key, (boolean) value));
+                if (currentEntry == null
+                        || currentEntry.getType() != RestrictionEntry.TYPE_BOOLEAN) {
+                    currentEntry = new RestrictionEntry(key, (boolean) value);
+                } else {
+                    currentEntry.setSelectedState((boolean) value);
+                }
+                restrictionEntries.add(currentEntry);
             } else if (value instanceof Integer) {
-                restrictionEntries.add(new RestrictionEntry(key, (int) value));
+                if (currentEntry == null
+                        || currentEntry.getType() != RestrictionEntry.TYPE_INTEGER) {
+                    currentEntry = new RestrictionEntry(key, (int) value);
+                } else {
+                    currentEntry.setIntValue((int) value);
+                }
+                restrictionEntries.add(currentEntry);
             } else if (value instanceof String) {
-                // DevicePolicyManager returns Choice restriction string
-                // We need to find corresponding restriction in app manifest restrictions
-                // and, if it has type Choice, use entries and values defined by app
-                RestrictionEntry entry = null;
-                Bundle manifestRestrictionData = null;
-                if (manifestRestrictionsBundle != null) {
-                    manifestRestrictionData = manifestRestrictionsBundle.getBundle(key);
-                }
-                if (manifestRestrictionData != null
-                        && manifestRestrictionData.containsKey(RestrictionManagerCompat.CHOICE_SELECTED_VALUE)) {
-                    String[] choiceEntries = manifestRestrictionData.getStringArray(RestrictionManagerCompat.CHOICE_ENTRIES);
-                    String[] choiceValues = manifestRestrictionData.getStringArray(RestrictionManagerCompat.CHOICE_VALUES);
-                    entry = new RestrictionEntry(RestrictionEntry.TYPE_CHOICE, key);
-                    entry.setChoiceEntries(choiceEntries);
-                    entry.setChoiceValues(choiceValues);
+                // DevicePolicyManager returns Choice restriction as string
+                // We will find correct type in app manifest restrictions
+                if (currentEntry == null
+                    || (currentEntry.getType() != RestrictionEntry.TYPE_STRING
+                        && currentEntry.getType() != RestrictionEntry.TYPE_CHOICE)) {
+                    currentEntry = new RestrictionEntry(RestrictionEntry.TYPE_STRING, key);
+                    currentEntry.setSelectedString((String) value);
                 } else {
-                    entry = new RestrictionEntry(RestrictionEntry.TYPE_STRING, key);
+                    currentEntry.setSelectedString((String) value);
                 }
-                entry.setSelectedString((String) value);
-                restrictionEntries.add(entry);
+                restrictionEntries.add(currentEntry);
             } else if (value instanceof String[]) {
-                restrictionEntries.add(new RestrictionEntry(key, (String[]) value));
-            } else if (value instanceof Bundle) {
-                // We are using Bundle to store Choice restriction for UI
-                if (((Bundle) value).containsKey(RestrictionManagerCompat.CHOICE_SELECTED_VALUE)) {
-                    addChoiceEntryToRestrictions(restrictionEntries, key, (Bundle) value);
+                if (currentEntry == null || currentEntry.getType() != RestrictionEntry.TYPE_MULTI_SELECT) {
+                    currentEntry = new RestrictionEntry(key, (String[]) value);
                 } else {
-                    Bundle manifestRestrictionData = null;
-                    if (manifestRestrictionsBundle != null) {
-                        manifestRestrictionData = manifestRestrictionsBundle.getBundle(key);
-                    }
+                    currentEntry.setAllSelectedStrings((String[]) value);
+                }
+                restrictionEntries.add(currentEntry);
+            } else if (value instanceof Bundle) {
                     addBundleEntryToRestrictions(
-                            restrictionEntries, key, (Bundle) value, manifestRestrictionData);
-                }
+                            restrictionEntries, key, (Bundle) value, currentEntry);
             } else if (value instanceof Parcelable[]) {
-                Parcelable[] manifestRestrictionData = null;
-                if (manifestRestrictionsBundle != null) {
-                    manifestRestrictionData = manifestRestrictionsBundle.getParcelableArray(key);
-                }
-                addBundleArrayToRestrictions(restrictionEntries, key, (Parcelable[]) value, manifestRestrictionData);
+                addBundleArrayToRestrictions(restrictionEntries, key, (Parcelable[]) value, currentEntry);
             }
         }
-        return restrictionEntries.toArray(new RestrictionEntry[0]);
+        return restrictionEntries;
+    }
+
+    private RestrictionEntry findRestrictionEntryByKey(
+            String key, List<RestrictionEntry> manifestRestrictions) {
+        if (!TextUtils.isEmpty(key) && manifestRestrictions != null) {
+            for (RestrictionEntry entry : manifestRestrictions) {
+                if (entry != null && key.equals(entry.getKey())) {
+                    return entry;
+                }
+            }
+        }
+        return null;
     }
 
     @TargetApi(Build.VERSION_CODES.M)
     private void addBundleEntryToRestrictions(List<RestrictionEntry> restrictionEntries,
-            String key, Bundle value, Bundle manifestRestrictionsBundle) {
-        restrictionEntries.add(RestrictionEntry.createBundleEntry(
-                key, convertBundleToRestrictions(value, manifestRestrictionsBundle)));
+            String key, Bundle value, RestrictionEntry currentEntry) {
+        if (currentEntry == null || currentEntry.getType() != RestrictionEntry.TYPE_BUNDLE) {
+            currentEntry = RestrictionEntry.createBundleEntry(
+                    key, convertBundleToRestrictions(value, null).toArray(new RestrictionEntry[0]));
+        } else {
+            currentEntry.setRestrictions(
+                convertBundleToRestrictions(value,
+                    new ArrayList<RestrictionEntry>(Arrays.asList(
+                            currentEntry.getRestrictions()))).toArray(new RestrictionEntry[0]));
+        }
+        restrictionEntries.add(currentEntry);
     }
 
     @TargetApi(Build.VERSION_CODES.M)
     private void addBundleArrayToRestrictions(List<RestrictionEntry> restrictionEntries,
-            String key, Parcelable[] value, Parcelable[] manifestRestrictionsBundleArray) {
+            String key, Parcelable[] value, RestrictionEntry manifestBundleArrayEntry) {
         int length = value.length;
+        String bundleKey = key;
+        RestrictionEntry bundleRestrictionFromManifest = null;
+        ArrayList<RestrictionEntry> bundleRestrictionEntriesFromManifest = null;
+        if (manifestBundleArrayEntry != null
+                && manifestBundleArrayEntry.getType() == RestrictionEntry.TYPE_BUNDLE_ARRAY) {
+            // In manifest restrictions BundleArray can contain one Bundle only
+            // to define bundles structure.
+            RestrictionEntry[] bundles = manifestBundleArrayEntry.getRestrictions();
+            if (bundles != null && bundles.length > 0 && bundles[0] != null) {
+                bundleRestrictionFromManifest = bundles[0];
+            }
+        }
+        // Make Bundles
         RestrictionEntry[] entriesArray = new RestrictionEntry[length];
         for (int i = 0; i < entriesArray.length; ++i) {
-            Parcelable manifestRestrictionsBundle = null;
-            if (manifestRestrictionsBundleArray != null && manifestRestrictionsBundleArray.length > i) {
-                manifestRestrictionsBundle = manifestRestrictionsBundleArray[i];
+            if (bundleRestrictionFromManifest != null) {
+                // We need to clone here to have new copy of manifest restrictions for each bundle
+                bundleRestrictionFromManifest = KeyValueUtil.cloneRestriction(
+                        bundleRestrictionFromManifest);
+                bundleKey = bundleRestrictionFromManifest.getKey();
+                bundleRestrictionEntriesFromManifest = new ArrayList<>(
+                    Arrays.asList(bundleRestrictionFromManifest.getRestrictions()));
             }
-            entriesArray[i] = RestrictionEntry.createBundleEntry(key,
-                    convertBundleToRestrictions((Bundle) value[i], (Bundle) manifestRestrictionsBundle));
+            entriesArray[i] = RestrictionEntry.createBundleEntry(bundleKey,
+                 convertBundleToRestrictions((Bundle) value[i],
+                     bundleRestrictionEntriesFromManifest).toArray(new RestrictionEntry[0]));
+            if (entriesArray[i] != null && bundleRestrictionFromManifest != null) {
+                entriesArray[i].setTitle(bundleRestrictionFromManifest.getTitle());
+                entriesArray[i].setDescription(bundleRestrictionFromManifest.getDescription());
+            }
         }
-        restrictionEntries.add(RestrictionEntry.createBundleArrayEntry(key, entriesArray));
-    }
-
-    private void addChoiceEntryToRestrictions(List<RestrictionEntry> restrictionEntries,
-                                              String key, Bundle value) {
-        RestrictionEntry choiceEntry = new RestrictionEntry(RestrictionEntry.TYPE_CHOICE, key);
-        choiceEntry.setSelectedString(value.getString(RestrictionManagerCompat.CHOICE_SELECTED_VALUE));
-        choiceEntry.setChoiceEntries(value.getStringArray(RestrictionManagerCompat.CHOICE_ENTRIES));
-        choiceEntry.setChoiceValues(value.getStringArray(RestrictionManagerCompat.CHOICE_VALUES));
-        restrictionEntries.add(choiceEntry);
+        // Set Bundles to Bundle array
+        if (manifestBundleArrayEntry == null
+                || manifestBundleArrayEntry.getType() != RestrictionEntry.TYPE_BUNDLE_ARRAY) {
+            manifestBundleArrayEntry = RestrictionEntry.createBundleArrayEntry(key, entriesArray);
+        } else {
+            manifestBundleArrayEntry.setRestrictions(entriesArray);
+        }
+        restrictionEntries.add(manifestBundleArrayEntry);
     }
 
     protected void showToast(String msg) {
@@ -209,76 +249,21 @@ public class ManageAppRestrictionsFragment extends ManageAppFragment
         int type = KeyValuePairDialogFragment.DialogType.BOOL_TYPE;
         Object value = null;
         String key = "";
-        if (restrictionEntry != null) {
-            key = restrictionEntry.getKey();
-            type = getTypeIndexFromRestrictionType(restrictionEntry.getType());
-            switch (restrictionEntry.getType()) {
-                case RestrictionEntry.TYPE_BOOLEAN:
-                    value = restrictionEntry.getSelectedState();
-                    break;
-                case RestrictionEntry.TYPE_INTEGER:
-                    value = restrictionEntry.getIntValue();
-                    break;
-                case RestrictionEntry.TYPE_STRING:
-                    value = restrictionEntry.getSelectedString();
-                    // UI uses value to find restriction type.
-                    // If string restrictions has null value, it will be displayed as boolean
-                    // To avoid this we should set empty string as value
-                    if (value == null) {
-                        value = "";
-                    }
-                    break;
-                case RestrictionEntry.TYPE_MULTI_SELECT:
-                    value = restrictionEntry.getAllSelectedStrings();
-                    break;
-                case RestrictionEntry.TYPE_BUNDLE:
-                    value = RestrictionManagerCompat.convertRestrictionsToBundle(Arrays.asList(
-                            getRestrictionEntries(restrictionEntry)), true);
-                    break;
-                case RestrictionEntry.TYPE_BUNDLE_ARRAY:
-                    RestrictionEntry[] restrictionEntries = getRestrictionEntries(restrictionEntry);
-                    Bundle[] bundles = new Bundle[restrictionEntries.length];
-                    for (int i = 0; i < restrictionEntries.length; i++) {
-                        bundles[i] =
-                                RestrictionManagerCompat.convertRestrictionsToBundle(Arrays.asList(
-                                        getRestrictionEntries(restrictionEntries[i])), true);
-                    }
-                    value = bundles;
-                    break;
-                case RestrictionEntry.TYPE_CHOICE:
-                    value = RestrictionManagerCompat.convertChoiceRestrictionToBundle(restrictionEntry);
-                    break;
-            }
+        if (mEditingRestrictionEntry != null) {
+            key = mEditingRestrictionEntry.getKey();
+            type = KeyValueUtil.getTypeIndexFromRestrictionType(mEditingRestrictionEntry.getType());
+        } else {
+            mEditingRestrictionEntry = new RestrictionEntry(key, false);
         }
+
         int[] supportType = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
                 ? SUPPORTED_TYPES_PRE_M
                 : SUPPORTED_TYPES;
         KeyValuePairDialogFragment dialogFragment =
-                KeyValuePairDialogFragment.newInstance(type, true, key, value, supportType,
-                        getCurrentAppName());
+                KeyValuePairDialogFragment.newInstance(type, true, key, value,
+                        mEditingRestrictionEntry, supportType, getCurrentAppName());
         dialogFragment.setTargetFragment(this, RESULT_CODE_EDIT_DIALOG);
         dialogFragment.show(getFragmentManager(), "dialog");
-    }
-
-    private int getTypeIndexFromRestrictionType(int restrictionType) {
-        switch (restrictionType) {
-            case RestrictionEntry.TYPE_BOOLEAN:
-                return KeyValuePairDialogFragment.DialogType.BOOL_TYPE;
-            case RestrictionEntry.TYPE_INTEGER:
-                return KeyValuePairDialogFragment.DialogType.INT_TYPE;
-            case RestrictionEntry.TYPE_STRING:
-                return KeyValuePairDialogFragment.DialogType.STRING_TYPE;
-            case RestrictionEntry.TYPE_MULTI_SELECT:
-                return KeyValuePairDialogFragment.DialogType.STRING_ARRAY_TYPE;
-            case RestrictionEntry.TYPE_BUNDLE:
-                return KeyValuePairDialogFragment.DialogType.BUNDLE_TYPE;
-            case RestrictionEntry.TYPE_BUNDLE_ARRAY:
-                return KeyValuePairDialogFragment.DialogType.BUNDLE_ARRAY_TYPE;
-            case RestrictionEntry.TYPE_CHOICE:
-                return KeyValuePairDialogFragment.DialogType.CHOICE_TYPE;
-            default:
-                throw new AssertionError("Unknown restriction type");
-        }
     }
 
     @Override
@@ -286,83 +271,20 @@ public class ManageAppRestrictionsFragment extends ManageAppFragment
         if (resultCode != Activity.RESULT_OK) {
             return;
         }
-        RestrictionEntry newRestrictionEntry;
+
         switch (requestCode) {
             case RESULT_CODE_EDIT_DIALOG:
-                int type = result.getIntExtra(KeyValuePairDialogFragment.RESULT_TYPE, 0);
-                String key = result.getStringExtra(KeyValuePairDialogFragment.RESULT_KEY);
-                int editedRestrictionType = getRestrictionTypeFromDialogType(type);
-                if (mEditingRestrictionEntry == null || mEditingRestrictionEntry.getType() != editedRestrictionType) {
-                    newRestrictionEntry = new RestrictionEntry(getRestrictionTypeFromDialogType(type),
-                            key);
-                    updateRestrictionEntryFromResultIntent(newRestrictionEntry, result);
-                    mAppRestrictionsArrayAdapter.remove(mEditingRestrictionEntry);
+                RestrictionEntry newRestrictionEntry = result.getParcelableExtra(RESULT_ENTRY);
+                if (newRestrictionEntry != null) {
+                    if (mEditingRestrictionEntry != null
+                            && mEditingRestrictionEntry.getKey().equals(newRestrictionEntry.getKey())) {
+                        mAppRestrictionsArrayAdapter.remove(mEditingRestrictionEntry);
+                    }
                     mAppRestrictionsArrayAdapter.add(newRestrictionEntry);
-                } else {
-                    updateRestrictionEntryFromResultIntent(mEditingRestrictionEntry, result);
+                    mAppRestrictionsArrayAdapter.notifyDataSetChanged();
                 }
                 mEditingRestrictionEntry = null;
                 break;
-        }
-    }
-
-    // TYPE_BUNDLE and TYPE_BUNDLE_ARRAY are only supported from M onward. It is blocked in the
-    // UI side.
-    @TargetApi(Build.VERSION_CODES.M)
-    private void updateRestrictionEntryFromResultIntent(RestrictionEntry restrictionEntry,
-            Intent intent) {
-        switch (restrictionEntry.getType()) {
-            case RestrictionEntry.TYPE_BOOLEAN:
-                restrictionEntry.setSelectedState(intent.getBooleanExtra(RESULT_VALUE, false));
-                break;
-            case RestrictionEntry.TYPE_INTEGER:
-                restrictionEntry.setIntValue(intent.getIntExtra(RESULT_VALUE, 0));
-                break;
-            case RestrictionEntry.TYPE_STRING:
-                restrictionEntry.setSelectedString(intent.getStringExtra(RESULT_VALUE));
-                break;
-            case RestrictionEntry.TYPE_MULTI_SELECT:
-                restrictionEntry.setAllSelectedStrings(intent.getStringArrayExtra(RESULT_VALUE));
-                break;
-            case RestrictionEntry.TYPE_BUNDLE: {
-                Bundle bundle = intent.getBundleExtra(RESULT_VALUE);
-                restrictionEntry.setRestrictions(convertBundleToRestrictions(bundle, null));
-                break;
-            }
-            case RestrictionEntry.TYPE_BUNDLE_ARRAY: {
-                Parcelable[] bundleArray = intent.getParcelableArrayExtra(RESULT_VALUE);
-                RestrictionEntry[] restrictionEntryArray = new RestrictionEntry[bundleArray.length];
-                for (int i = 0; i< bundleArray.length; i++) {
-                    restrictionEntryArray[i] = RestrictionEntry.createBundleEntry(String.valueOf(i),
-                            convertBundleToRestrictions((Bundle) bundleArray[i], null));
-                }
-                restrictionEntry.setRestrictions(restrictionEntryArray);
-                break;
-            }
-            case RestrictionEntry.TYPE_CHOICE:
-                restrictionEntry.setSelectedString(intent.getStringExtra(RESULT_VALUE));
-                break;
-        }
-    }
-
-    private int getRestrictionTypeFromDialogType(int typeIndex) {
-        switch (typeIndex) {
-            case KeyValuePairDialogFragment.DialogType.BOOL_TYPE:
-                return RestrictionEntry.TYPE_BOOLEAN;
-            case KeyValuePairDialogFragment.DialogType.INT_TYPE:
-                return RestrictionEntry.TYPE_INTEGER;
-            case KeyValuePairDialogFragment.DialogType.STRING_TYPE:
-                return RestrictionEntry.TYPE_STRING;
-            case KeyValuePairDialogFragment.DialogType.STRING_ARRAY_TYPE:
-                return RestrictionEntry.TYPE_MULTI_SELECT;
-            case KeyValuePairDialogFragment.DialogType.BUNDLE_TYPE:
-                return RestrictionEntry.TYPE_BUNDLE;
-            case KeyValuePairDialogFragment.DialogType.BUNDLE_ARRAY_TYPE:
-                return RestrictionEntry.TYPE_BUNDLE_ARRAY;
-            case KeyValuePairDialogFragment.DialogType.CHOICE_TYPE:
-                return RestrictionEntry.TYPE_CHOICE;
-            default:
-                throw new AssertionError("Unknown type index");
         }
     }
 
@@ -393,13 +315,12 @@ public class ManageAppRestrictionsFragment extends ManageAppFragment
         if (!TextUtils.isEmpty(pkgName)) {
             Bundle bundle = mDevicePolicyManager.getApplicationRestrictions(
                     DeviceAdminReceiver.getComponentName(getActivity()), pkgName);
-            // We need restrictions from app manifest to get entries and values for Choice restrictions
-            List<RestrictionEntry> manifestRestrictions = getManifestRestrictions(pkgName);
-            Bundle manifestRestrictionsBundle = null;
-            if (manifestRestrictions != null) {
-                manifestRestrictionsBundle = RestrictionManagerCompat.convertRestrictionsToBundle(manifestRestrictions, true);
-            }
-            loadAppRestrictionsList(convertBundleToRestrictions(bundle, manifestRestrictionsBundle));
+            // We will use restrictions from app manifest as basis and will update values
+            // saved by user via DevicePolicyManager
+            // Also, we will load custom restrictions added by user (not defined in app manifest)
+            ArrayList<RestrictionEntry> manifestRestrictions = getManifestRestrictions(pkgName);
+            convertTypeNullToString(manifestRestrictions);
+            loadAppRestrictionsList(convertBundleToRestrictions(bundle, manifestRestrictions));
             mLastRestrictionEntries = new ArrayList<>(mRestrictionEntries);
         }
     }
@@ -418,22 +339,22 @@ public class ManageAppRestrictionsFragment extends ManageAppFragment
         if (!TextUtils.isEmpty(pkgName)) {
             List<RestrictionEntry> manifestRestrictions = getManifestRestrictions(pkgName);
             if (manifestRestrictions != null) {
-                loadAppRestrictionsList(manifestRestrictions.toArray(new RestrictionEntry[0]));
+                loadAppRestrictionsList(manifestRestrictions);
             }
         }
     }
 
-    private List<RestrictionEntry> getManifestRestrictions(String pkgName) {
-        List<RestrictionEntry> manifestRestrictions = null;
+    private ArrayList<RestrictionEntry> getManifestRestrictions(String pkgName) {
+        ArrayList<RestrictionEntry> manifestRestrictions = null;
         if (!TextUtils.isEmpty(pkgName)) {
             try {
-                manifestRestrictions = mRestrictionsManager.getManifestRestrictions(pkgName);
+                manifestRestrictions = new ArrayList<>(mRestrictionsManager.getManifestRestrictions(
+                    pkgName));
                 convertTypeNullToString(manifestRestrictions);
             } catch (NullPointerException e) {
                 // This means no default restrictions.
             }
         }
-
         return manifestRestrictions;
     }
 
@@ -441,6 +362,8 @@ public class ManageAppRestrictionsFragment extends ManageAppFragment
      * TODO (b/23378519): Remove this method and add support for type null.
      */
     private void convertTypeNullToString(List<RestrictionEntry> restrictionEntries) {
+        if (restrictionEntries == null)
+            return;
         for (RestrictionEntry entry : restrictionEntries) {
             if (entry.getType() == RestrictionEntry.TYPE_NULL) {
                 entry.setType(RestrictionEntry.TYPE_STRING);
@@ -454,7 +377,7 @@ public class ManageAppRestrictionsFragment extends ManageAppFragment
                 ((ApplicationInfo) mManagedAppsSpinner.getSelectedItem()).packageName;
         mDevicePolicyManager.setApplicationRestrictions(
                 DeviceAdminReceiver.getComponentName(getActivity()), pkgName,
-                RestrictionManagerCompat.convertRestrictionsToBundle(mRestrictionEntries, false));
+                RestrictionManagerCompat.convertRestrictionsToBundle(mRestrictionEntries));
         mLastRestrictionEntries = new ArrayList<>(mRestrictionEntries);
         showToast(getString(R.string.set_app_restrictions_success, pkgName));
     }
@@ -469,11 +392,6 @@ public class ManageAppRestrictionsFragment extends ManageAppFragment
     protected void loadDefault() {
         loadManifestAppRestrictions(
                 ((ApplicationInfo) mManagedAppsSpinner.getSelectedItem()).packageName);
-    }
-
-    @TargetApi(Build.VERSION_CODES.M)
-    private RestrictionEntry[] getRestrictionEntries(RestrictionEntry restrictionEntry) {
-        return restrictionEntry.getRestrictions();
     }
 
     public class RestrictionEntryEditDeleteArrayAdapter extends

--- a/app/src/main/res/layout/basic_key_value_pair.xml
+++ b/app/src/main/res/layout/basic_key_value_pair.xml
@@ -116,6 +116,14 @@
                 android:paddingTop="8dp"
                 android:visibility="gone"/>
 
+            <Spinner
+                android:id="@+id/value_choice_spinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:textAlignment="viewStart"
+                android:visibility="gone"/>
+
         <LinearLayout
                 android:id="@+id/value_str_array_container"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -403,6 +403,7 @@
     <string name="value_not_valid">Restriction value is not valid</string>
     <string name="restriction_save_label">Save</string>
     <string name="restriction_cancel_label">Cancel</string>
+    <string name="key_already_exists_error">Key %1$s already exists. Cannot add</string>
     <!-- Text shown in configure button when bundle/bundle array is chosen -->
     <string name="configure">Configure</string>
 


### PR DESCRIPTION
Hello!

  I have submitted Issue #20 few days ago. This is fix for it.

 Changes:
1. Implement Choice restriction support. Entries and values for choice restriction are used from application manifest restrictions definition.
2. Fix issue with incorrect String restriction type inside Bundle. If String restriction has null default value it was displayed as Boolean in UI inside Bundle.
3. Sort restrictions in alphabetic order inside Bundle.
4. When user creates new Bundle inside BundleArray restriction, init it with same restrictions as first existing bundle in same array instead of making empty Bundle.