### PR TITLE
The project does not build becuase of a dependency that is not locked

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     implementation 'com.android.support:recyclerview-v7:27.0.2'
     implementation 'com.android.support:support-v13:27.0.2'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation 'com.google.android.gms:play-services-safetynet:+'
+    implementation 'com.google.android.gms:play-services-safetynet:11.8.0'
     implementation(name: 'setup-wizard-lib-platform-release', ext: 'aar')
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.56'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.56'


### PR DESCRIPTION
This is related to ISSUE-59, and temporarily gets the project building again by locking in the
safety net dependency where it matches the current code base.