### PR TITLE
Fix SDK version used to build TestDPC

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 android {
-    compileSdkVersion 'android-P'
+    compileSdkVersion 'android-28'
 
     defaultConfig {
         applicationId "com.afwsamples.testdpc"


### PR DESCRIPTION
The build file pointed to android-P, which was correct during P
development, but for external SDK use the version should be
'android-28'.