### PR TITLE
Fix for #79 crash 

### DIFF
--- a/app/src/main/java/com/afwsamples/testdpc/common/ProfileOrParentFragment.java
+++ b/app/src/main/java/com/afwsamples/testdpc/common/ProfileOrParentFragment.java
@@ -61,7 +61,7 @@ public abstract class ProfileOrParentFragment extends BaseSearchablePolicyPrefer
         public View onCreateView(
                 LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
             FragmentTabHost tabHost = new FragmentTabHost(getActivity());
-            tabHost.setup(getActivity(), getChildFragmentManager(), View.generateViewId());
+            tabHost.setup(getActivity(), getChildFragmentManager(), container.getId());
 
             final boolean showDualTabs =
                 Util.isManagedProfileOwner(getActivity())


### PR DESCRIPTION
Hello Team,
  
I am submitting fix for https://github.com/googlesamples/android-testdpc/issues/79. Please have a look.
Changes:
    Using containerId provided with  onCreateView->ViewGroup , as on popBackStack() random generated container id was not getting matched and failing to map view.

Thanks