### PR TITLE
autoGrantRequestedPermissionToSelf() taking time on low-end device

### DIFF
--- a/app/src/main/java/com/afwsamples/testdpc/provision/PostProvisioningTask.java
+++ b/app/src/main/java/com/afwsamples/testdpc/provision/PostProvisioningTask.java
@@ -83,7 +83,9 @@ public class PostProvisioningTask {
         // From M onwards, permissions are not auto-granted, so we need to manually grant
         // permissions for TestDPC.
         if (Util.SDK_INT >= VERSION_CODES.M) {
-            autoGrantRequestedPermissionsToSelf();
+            new Thread (() -> {
+                autoGrantRequestedPermissionsToSelf();
+            }).start();
         }
 
         // Retreive the admin extras bundle, which we can use to determine the original context for


### PR DESCRIPTION
autoGrantRequestedPermissionToSelf()  takes time on low end devices causing the application to crash.
Calling the method on a separate thread, to avoid blocking the UI Thread and the resulting application crash