### PR TITLE
Corrected input type for managed configuration dialog to allow for signed integers.

### DIFF
--- a/app/src/main/res/layout/basic_key_value_pair.xml
+++ b/app/src/main/res/layout/basic_key_value_pair.xml
@@ -103,7 +103,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
-                android:inputType="number"
+                android:inputType="numberSigned"
                 android:paddingTop="8dp"
                 android:visibility="gone"/>
 


### PR DESCRIPTION
Corrected input type for managed configuration dialog to allow for signed integers.

Before this it was not possible to set a negative integer value, but they are supported (https://developer.android.com/work/managed-configurations)