### PR TITLE
extra finish call in GetProvisioningModeActivity

### DIFF
--- a/src/main/java/com/afwsamples/testdpc/provision/GetProvisioningModeActivity.java
+++ b/src/main/java/com/afwsamples/testdpc/provision/GetProvisioningModeActivity.java
@@ -51,7 +51,6 @@ public class GetProvisioningModeActivity extends Activity {
     if (ProvisioningUtil.isAutoProvisioningDeviceOwnerMode()) {
         Log.i(TAG, "Automatically provisioning device onwer");
         onDoButtonClick(null);
-        finish();
     }
 
     setContentView(R.layout.activity_get_provisioning_mode);


### PR DESCRIPTION
I've noticed an extra finish call in GetProvisioningModeActivity if autoprovisioning happens