### PR TITLE
Update build.sh & gitignore & fix crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bazel-android-testdpc
+bazel-bin
+bazel-out
+bazel-testlogs
+**/*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the [documentation](https://developer.android.com/work/index.html) to learn 
 Getting Started
 ---------------
 
-This sample uses the Bazel build system. To build this project, use the "bazel build --noincremental_dexing" command.
+This sample uses the Bazel build system. To build this project, use the "bazel build testdpc" command.
 
 This app can also be found [on the Play store](https://play.google.com/store/apps/details?id=com.afwsamples.testdpc).
 

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@
 # Fail on any error.
 set -e
 
-bazel build --noincremental_dexing testdpc
+bazel build testdpc

--- a/src/main/java/com/afwsamples/testdpc/DevicePolicyManagerGatewayImpl.java
+++ b/src/main/java/com/afwsamples/testdpc/DevicePolicyManagerGatewayImpl.java
@@ -16,6 +16,8 @@
 
 package com.afwsamples.testdpc;
 
+import static com.afwsamples.testdpc.common.Util.isAtLeastT;
+
 import android.app.admin.DevicePolicyManager;
 import android.app.admin.NetworkEvent;
 import android.app.admin.SecurityLog.SecurityEvent;
@@ -636,7 +638,11 @@ public final class DevicePolicyManagerGatewayImpl implements DevicePolicyManager
   public boolean isPreferentialNetworkServiceEnabled() {
     Util.requireAndroidS();
 
-    return mDevicePolicyManager.isPreferentialNetworkServiceEnabled();
+    if (isAtLeastT()) {
+      return mDevicePolicyManager.isPreferentialNetworkServiceEnabled();
+    }
+
+    return false;
   }
 
   @Override


### PR DESCRIPTION
- Fix build failure when using latest Bazel 6.2.1
  - Issue was: `Error: Cannot fit requested classes in a single dex file`
  - Removing `--noincremental_dexing` fixes the issue
    
- Update `README.md` to reflect the `build.sh` fix
- Add build artifact & IDE files to a new `.gitignore`
- Fix crash on Android 12 / 12.1 when TestDPC is device owner