### PR TITLE
Fix crashes

### DIFF
--- a/src/main/res/xml/device_policy_header.xml
+++ b/src/main/res/xml/device_policy_header.xml
@@ -100,6 +100,7 @@
         <com.afwsamples.testdpc.common.preference.DpcPreference
             android:key="cross_profile_calendar"
             android:title="@string/cross_profile_calendar"
+            testdpc:admin="orgOwnedProfileOwner|profileOwner"
             testdpc:minSdkVersion="Q" />
     </PreferenceCategory>
 

--- a/src/main/res/xml/device_policy_header.xml
+++ b/src/main/res/xml/device_policy_header.xml
@@ -346,7 +346,7 @@
             android:key="enable_wifi_config_lockdown"
             android:title="@string/enable_wifi_config_lockdown"
             testdpc:admin="deviceOwner|orgOwnedProfileOwner"
-            testdpc:minSdkVersion="M" />
+            testdpc:minSdkVersion="R" />
         <com.afwsamples.testdpc.common.preference.DpcPreference
             android:key="modify_wifi_configuration"
             android:title="@string/modify_wifi_configuration"


### PR DESCRIPTION
```
java.lang.NoSuchMethodError: No virtual method setConfiguredNetworksLockdownState(Landroid/content/ComponentName;Z)V in class Landroid/app/admin/DevicePolicyManager; or its super classes (declaration of 'android.app.admin.DevicePolicyManager' appears in /system/framework/framework.jar)
```

![image](https://github.com/user-attachments/assets/2b74bf9d-ecac-46b9-9dc0-77ca9e92d3ba)
